### PR TITLE
src/Boolector.hs: add MonadFail instances

### DIFF
--- a/boolector.cabal
+++ b/boolector.cabal
@@ -37,6 +37,8 @@ library
         temporary,
         directory,
         time
+  if impl(ghc < 8.0)
+    build-depends: fail == 4.9.0.0
 
   ghc-options: -Wall -fno-warn-orphans
   build-tools:      c2hs

--- a/src/Boolector.hs
+++ b/src/Boolector.hs
@@ -257,6 +257,10 @@ import Data.Time.Clock.System
 import Prelude hiding (read, not, and, or, const, concat, repeat)
 import qualified Prelude as Prelude
 
+#if MIN_VERSION_base(4,9,0)
+import qualified Control.Monad.Fail as Fail
+#endif
+
 --
 -- Boolector monad
 --
@@ -278,7 +282,12 @@ data BoolectorState = BoolectorState { unBoolectorState :: B.Btor
 
 -- | Bolector monad, keeping track of underlying solver state.
 newtype Boolector a = Boolector { unBoolector :: StateT BoolectorState IO a }
-    deriving (Functor, Applicative, Monad, MonadState BoolectorState, MonadIO)
+    deriving
+      ( Functor, Applicative, Monad, MonadState BoolectorState, MonadIO
+#if MIN_VERSION_base(4,9,0)
+      , Fail.MonadFail
+#endif
+      )
 
 -- | Evaluate a Boolector action with a given configurations.
 evalBoolector :: BoolectorState -> Boolector a -> IO a

--- a/src/Boolector.hs
+++ b/src/Boolector.hs
@@ -238,6 +238,7 @@ module Boolector ( -- * Boolector monadic computations
 import Boolector.Foreign (Option(..), Status(..))
 import qualified Boolector.Foreign as B
 
+import qualified Control.Monad.Fail as Fail
 import Data.Char (isDigit)
 import Data.Maybe (listToMaybe)
 import Data.Map (Map)
@@ -256,10 +257,6 @@ import Data.Time.Clock.System
 
 import Prelude hiding (read, not, and, or, const, concat, repeat)
 import qualified Prelude as Prelude
-
-#if MIN_VERSION_base(4,9,0)
-import qualified Control.Monad.Fail as Fail
-#endif
 
 --
 -- Boolector monad
@@ -282,12 +279,7 @@ data BoolectorState = BoolectorState { unBoolectorState :: B.Btor
 
 -- | Bolector monad, keeping track of underlying solver state.
 newtype Boolector a = Boolector { unBoolector :: StateT BoolectorState IO a }
-    deriving
-      ( Functor, Applicative, Monad, MonadState BoolectorState, MonadIO
-#if MIN_VERSION_base(4,9,0)
-      , Fail.MonadFail
-#endif
-      )
+    deriving (Functor, Applicative, Monad, MonadState BoolectorState, MonadIO, Fail.MonadFail)
 
 -- | Evaluate a Boolector action with a given configurations.
 evalBoolector :: BoolectorState -> Boolector a -> IO a


### PR DESCRIPTION
Without this change, the test suite for this package fails to compile on GHC 8.6.4.